### PR TITLE
fix filepath uri on windows and space in filepath

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -193,6 +193,18 @@ export function activate(context: vscode.ExtensionContext) {
 			synchronize: {
 				fileEvents: vscode.workspace.createFileSystemWatcher("**/.k"),
 			},
+			uriConverters: {
+				// by default the URI sent over the protocol will be percent encoded (see rfc3986#section-2.1)
+				// the "workaround" below disables temporarily the encoding until decoding is implemented properly in clangd
+				// see alse: https://github.com/microsoft/vscode/issues/144698
+				// see alse: https://github.com/mono/linux-packaging-mono/blob/1d6753294b2993e1fbf92de9366bb9544db4189b/external/llvm-project/clang-tools-extra/clangd/clients/clangd-vscode/src/extension.ts#L30
+				code2Protocol: (uri: vscode.Uri) : string => {
+					let s = uri.toString(true);
+					console.log("url2str: ", s);
+					return s;
+				},
+				protocol2Code: (uri: string) : vscode.Uri => vscode.Uri.parse(uri)
+			},
 			traceOutputChannel,
 		};
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #19

#### 2. What is the scope of this PR (e.g. component or file name):
 src/extension.ts

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Other

Special characters in URI like `:` and space will be escaped, this cause vscode not to work properly.
* [vscode-languageclient escapes drive colon on doc URIs on Win](https://github.com/microsoft/vscode/issues/144698)
* [code from repository linux-packaging-mono](https://github.com/mono/linux-packaging-mono/blob/1d6753294b2993e1fbf92de9366bb9544db4189b/external/llvm-project/clang-tools-extra/clangd/clients/clangd-vscode/src/extension.ts#L30)

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 


#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [x] Manual test (add detailed scripts or steps below)
- [ ] Other

#### 6. Release note

